### PR TITLE
Add a markdown renderer and simplify output format

### DIFF
--- a/due_date_warner/main.py
+++ b/due_date_warner/main.py
@@ -43,7 +43,6 @@ argument_parser.add_argument(
          "will be listed. (default: 60)"
 )
 
-
 argument_parser.add_argument(
     "--renderer",
     type=str,
@@ -54,7 +53,6 @@ argument_parser.add_argument(
          "html.py for rendering"
 )
 
-
 argument_parser.add_argument(
     "--days-urgent",
     type=int,
@@ -63,13 +61,21 @@ argument_parser.add_argument(
          "output will be marked 'urgent'"
 )
 
-
 argument_parser.add_argument(
     "--days-soon",
     type=int,
     default=14,
     help="Number of days from today + 'urgent' days for which the "
          "output will be marked 'soon', i.e. yellow"
+)
+
+argument_parser.add_argument(
+    "--html-output",
+    action="store_true",
+    default=False,
+    help="Emit an html table. This argument exists for backward compatibility, "
+         "it takes precedence over renderer via '--renderer'. Instead of this "
+         "parameter you should use '--renderer=html'."
 )
 
 
@@ -261,7 +267,7 @@ def cli():
             f"{arguments.max_days_to_check} were found.")
     else:
         show_result(
-            arguments.renderer,
+            arguments.renderer if arguments.html_output is False else "html",
             due_items,
             arguments.days_urgent,
             arguments.days_soon)

--- a/due_date_warner/renderer/__init__.py
+++ b/due_date_warner/renderer/__init__.py
@@ -1,15 +1,6 @@
 from enum import Enum
 
 
-table_headers = [
-    "Due date",
-    "Project",
-    "Item description",
-    "Item or Project URL",
-    "Project URL"
-]
-
-
 class DayCategory(Enum):
     over_due = 0
     urgent = 1

--- a/due_date_warner/renderer/__init__.py
+++ b/due_date_warner/renderer/__init__.py
@@ -1,0 +1,31 @@
+from enum import Enum
+
+
+table_headers = [
+    "Due date",
+    "Project",
+    "Item description",
+    "Item or Project URL",
+    "Project URL"
+]
+
+
+class DayCategory(Enum):
+    over_due = 0
+    urgent = 1
+    soon = 2
+    later = 3
+
+
+def get_date_category(days_left: int,
+                      urgent_days: int = 14,
+                      soon_days: int = 14
+                      ) -> DayCategory:
+
+    if days_left < 0:
+        return DayCategory.over_due
+    if days_left <= urgent_days:
+        return DayCategory.urgent
+    if days_left <= urgent_days + soon_days:
+        return DayCategory.soon
+    return DayCategory.later

--- a/due_date_warner/renderer/console.py
+++ b/due_date_warner/renderer/console.py
@@ -12,9 +12,8 @@ colorama.init()
 
 console_table_headers = [
     "Due date",
-    "Item description",
-    "Project name",
-    "Project URL"
+    "Item",
+    "Project",
 ]
 
 
@@ -27,6 +26,8 @@ category_to_colorama = {
 
 
 def limit_string(string: str, max_length: int) -> str:
+    if len(string) < max_length:
+        return string + (" " * (max_length - len(string)))
     return string[:max_length - 4] + " ..." \
            if len(string) >= max_length \
            else string
@@ -42,8 +43,6 @@ def show_result(due_items: List[Tuple[datetime, str, str, str, str]],
     table.field_names = console_table_headers
 
     table.align = "l"
-    table.align["Item"] = "r"
-
     for entry in sorted(due_items):
 
         due_time, project, item, item_url, project_url = entry
@@ -55,9 +54,8 @@ def show_result(due_items: List[Tuple[datetime, str, str, str, str]],
 
         table.add_row([
             fg + bg + due_time.strftime("%Y-%m-%d") + reset,
-            limit_string(item, 40),
-            limit_string(project, 40),
-            project_url
+            limit_string(item, 40) + " (" + item_url + ")" if item_url else item,
+            limit_string(project, 40) + " (" + project_url + ")"
         ])
 
     print(table)

--- a/due_date_warner/renderer/console.py
+++ b/due_date_warner/renderer/console.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from typing import List, Tuple
+
+import colorama
+from prettytable import PrettyTable
+
+from . import DayCategory, get_date_category, table_headers
+
+
+colorama.init()
+
+
+category_to_colorama = {
+    DayCategory.over_due: (colorama.Fore.BLACK, colorama.Back.RED),
+    DayCategory.urgent: (colorama.Fore.RED, ""),
+    DayCategory.soon: (colorama.Fore.YELLOW, ""),
+    DayCategory.later: (colorama.Fore.GREEN, "")
+}
+
+
+def limit_string(string: str, max_length: int) -> str:
+    return string[:max_length - 3] + "..." \
+           if len(string) >= max_length \
+           else string
+
+
+def show_result(due_items: List[Tuple[datetime, str, str, str, str]],
+                urgent_days: int = 14,
+                soon_days: int = 30,
+                ) -> None:
+
+    reset = colorama.Style.RESET_ALL
+    table = PrettyTable()
+    table.field_names = table_headers
+
+    table.align = "l"
+    table.align["Item"] = "r"
+
+    for entry in sorted(due_items):
+
+        due_time, project, item, item_url, project_url = entry
+        now = datetime.now(tz=due_time.tzinfo)
+        days_left = (due_time - now).days
+
+        fg, bg = category_to_colorama[
+            get_date_category(days_left, urgent_days, soon_days)]
+
+        table.add_row([
+            fg + bg + due_time.strftime("%Y-%m-%d") + reset,
+            limit_string(project, 30),
+            limit_string(item, 40),
+            item_url,
+            project_url
+        ])
+
+    print(table)

--- a/due_date_warner/renderer/console.py
+++ b/due_date_warner/renderer/console.py
@@ -4,10 +4,18 @@ from typing import List, Tuple
 import colorama
 from prettytable import PrettyTable
 
-from . import DayCategory, get_date_category, table_headers
+from . import DayCategory, get_date_category
 
 
 colorama.init()
+
+
+console_table_headers = [
+    "Due date",
+    "Item description",
+    "Project name",
+    "Project URL"
+]
 
 
 category_to_colorama = {
@@ -19,7 +27,7 @@ category_to_colorama = {
 
 
 def limit_string(string: str, max_length: int) -> str:
-    return string[:max_length - 3] + "..." \
+    return string[:max_length - 4] + " ..." \
            if len(string) >= max_length \
            else string
 
@@ -31,7 +39,7 @@ def show_result(due_items: List[Tuple[datetime, str, str, str, str]],
 
     reset = colorama.Style.RESET_ALL
     table = PrettyTable()
-    table.field_names = table_headers
+    table.field_names = console_table_headers
 
     table.align = "l"
     table.align["Item"] = "r"
@@ -47,9 +55,8 @@ def show_result(due_items: List[Tuple[datetime, str, str, str, str]],
 
         table.add_row([
             fg + bg + due_time.strftime("%Y-%m-%d") + reset,
-            limit_string(project, 30),
             limit_string(item, 40),
-            item_url,
+            limit_string(project, 40),
             project_url
         ])
 

--- a/due_date_warner/renderer/html.py
+++ b/due_date_warner/renderer/html.py
@@ -2,7 +2,14 @@ from datetime import datetime
 from typing import List, Tuple
 
 
-from . import DayCategory, get_date_category, table_headers
+from . import DayCategory, get_date_category
+
+
+html_table_headers = [
+    "Due date",
+    "Item",
+    "Project",
+]
 
 
 category_to_html = {
@@ -11,6 +18,12 @@ category_to_html = {
     DayCategory.soon: "yellow",
     DayCategory.later: "green",
 }
+
+
+def anchor(name: str,
+           url: str
+           ) -> str:
+    return f'<a href="{url}">{name}</a>'
 
 
 def show_result(due_items: List[Tuple[datetime, str, str, str, str]],
@@ -23,7 +36,7 @@ def show_result(due_items: List[Tuple[datetime, str, str, str, str]],
 
     print("<table>")
     print("  <tr>")
-    for header in table_headers:
+    for header in html_table_headers:
         print_cell(header, "th")
     print("  </tr>")
 
@@ -38,9 +51,8 @@ def show_result(due_items: List[Tuple[datetime, str, str, str, str]],
         print(
             f'   <td><font color="{category_to_html[category]}">'
             f'{due_time.strftime("%Y-%m-%d")}</font></td>')
-
-        for content in [project, item, item_url, project_url]:
-            print_cell(content)
-
+        print_cell(anchor(item, item_url) if item_url else item)
+        print_cell(anchor(project, project_url))
         print("  </tr>")
+
     print("</table>")

--- a/due_date_warner/renderer/html.py
+++ b/due_date_warner/renderer/html.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from typing import List, Tuple
+
+
+from . import DayCategory, get_date_category, table_headers
+
+
+category_to_html = {
+    DayCategory.over_due: "darkred",
+    DayCategory.urgent: "red",
+    DayCategory.soon: "yellow",
+    DayCategory.later: "green",
+}
+
+
+def show_result(due_items: List[Tuple[datetime, str, str, str, str]],
+                urgent_days: int = 14,
+                soon_days: int = 30,
+                ) -> None:
+
+    def print_cell(content: str, tag: str = "td"):
+        print(f"    <{tag}>{content}</{tag}>")
+
+    print("<table>")
+    print("  <tr>")
+    for header in table_headers:
+        print_cell(header, "th")
+    print("  </tr>")
+
+    for entry in sorted(due_items):
+        print("  <tr>")
+
+        due_time, project, item, item_url, project_url = entry
+        now = datetime.now(tz=due_time.tzinfo)
+        days_left = (due_time - now).days
+
+        category = get_date_category(days_left, urgent_days, soon_days)
+        print(
+            f'   <td><font color="{category_to_html[category]}">'
+            f'{due_time.strftime("%Y-%m-%d")}</font></td>')
+
+        for content in [project, item, item_url, project_url]:
+            print_cell(content)
+
+        print("  </tr>")
+    print("</table>")

--- a/due_date_warner/renderer/markdown.py
+++ b/due_date_warner/renderer/markdown.py
@@ -20,6 +20,8 @@ def show_result(due_items: List[Tuple[datetime, str, str, str, str]],
         if category in (DayCategory.over_due, DayCategory.urgent):
             date_string = "**" + date_string + "**"
 
+        if item_url:
+            item = "[" + item + "](" + item_url + ")"
         print(
             date_string + " --- *" + item + "* - [" + project + "](" +
             project_url + ")  ")

--- a/due_date_warner/renderer/markdown.py
+++ b/due_date_warner/renderer/markdown.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from typing import List, Tuple
+
+from . import DayCategory, get_date_category
+
+
+def show_result(due_items: List[Tuple[datetime, str, str, str, str]],
+                urgent_days: int = 14,
+                soon_days: int = 30,
+                ) -> None:
+
+    for entry in sorted(due_items):
+
+        due_time, project, item, item_url, project_url = entry
+        now = datetime.now(tz=due_time.tzinfo)
+        days_left = (due_time - now).days
+
+        date_string = due_time.strftime("%Y-%m-%d")
+        category = get_date_category(days_left, urgent_days, soon_days)
+        if category in (DayCategory.over_due, DayCategory.urgent):
+            date_string = "**" + date_string + "**"
+
+        print(
+            date_string + " --- *" + item + "* - [" + project + "](" +
+            project_url + ")  ")


### PR DESCRIPTION
This PR fixes issue #4 and issue #6 

A new markdown renderer is added. Its name is "markdown".

The number of output columns in all three renderers ("console", "html", and "markdown") is now 3, leading to better readability.


