### PR TITLE
Consolidate pagination processing

### DIFF
--- a/due_date_warner/main.py
+++ b/due_date_warner/main.py
@@ -5,7 +5,7 @@ import sys
 from collections import defaultdict
 from datetime import datetime
 from importlib import import_module
-from typing import Dict, Iterator, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from python_graphql_client import GraphqlClient
 
@@ -125,7 +125,7 @@ def process_item(client: GraphqlClient,
                  item: Dict,
                  project_title: str,
                  project_url: str
-                 ) -> List:
+                 ) -> Iterable:
 
     # Transform item fieldValues collection to a dictionary
     fields = item_field_values_to_dict(item)
@@ -148,15 +148,15 @@ def process_item(client: GraphqlClient,
         }
 
     if fields.get("Status") == github_done_status:
-        return []
+        return
     if "Due" not in fields:
-        return []
+        return
 
     due_date = datetime.fromisoformat(fields["Due"])
     now = datetime.now(tz=due_date.tzinfo)
     days_left = (due_date - now).days
     if days_left > max_days:
-        return []
+        return
 
     url = project_url
     if item["type"] in ("ISSUE", "PULL_REQUEST"):
@@ -172,19 +172,18 @@ def process_item(client: GraphqlClient,
     else:
         url = project_url
 
-    return [(
+    yield(
         due_date,
         project_title,
         item["title"],
         url,
-        project_url
-    )]
+        project_url)
 
 
 def process_project(client: GraphqlClient,
                     project_holder: Dict,
                     max_days: int
-                    ) -> List:
+                    ) -> Iterable:
 
     if project_holder is None:
         raise RuntimeError(
@@ -208,17 +207,14 @@ def process_project(client: GraphqlClient,
         items = additional_items["data"]["node"]["items"]
         project["items"]["edges"].extend(items["edges"])
 
-    due_items = []
     for item in project["items"]["edges"]:
-        due_items.extend(
-            process_item(client, max_days, item["node"], title, url))
-    return due_items
+        yield from process_item(client, max_days, item["node"], title, url)
 
 
 def read_due_items(client: GraphqlClient,
                    organization: str,
                    max_days: int
-                   ) -> List[Tuple[datetime, str, str, str, str]]:
+                   ) -> Iterable[Tuple[datetime, str, str, str, str]]:
 
     project_cursor = None
     item_cursor = None
@@ -233,11 +229,10 @@ def read_due_items(client: GraphqlClient,
         }
     )
 
-    due_items = []
     organization_id = result["data"]["organization"]["id"]
     projects_next = result["data"]["organization"]["projectsNext"]
     for project in projects_next["edges"]:
-        due_items.extend(process_project(client, project, max_days))
+        yield from process_project(client, project, max_days)
 
     while projects_next["pageInfo"]["hasNextPage"]:
         end_cursor = projects_next["pageInfo"]["endCursor"]
@@ -253,9 +248,7 @@ def read_due_items(client: GraphqlClient,
         organization_id = result["data"]["node"]["id"]
         projects_next = result["data"]["node"]["projectsNext"]
         for project in projects_next["edges"]:
-            due_items.extend(process_project(client, project, max_days))
-
-    return due_items
+            yield from process_project(client, project, max_days)
 
 
 def cli():
@@ -274,10 +267,11 @@ def cli():
         endpoint="https://api.github.com/graphql",
         headers={"Authorization": f"token {token}"})
 
-    due_items = read_due_items(
-        client,
-        arguments.organization,
-        arguments.max_days_to_check)
+    due_items = list(
+        read_due_items(
+            client,
+            arguments.organization,
+            arguments.max_days_to_check))
 
     if len(due_items) == 0:
         print(

--- a/due_date_warner/main.py
+++ b/due_date_warner/main.py
@@ -216,17 +216,10 @@ def read_due_items(client: GraphqlClient,
                    max_days: int
                    ) -> Iterable[Tuple[datetime, str, str, str, str]]:
 
-    project_cursor = None
-    item_cursor = None
-
     result = process_query(
         client,
         query_due,
-        {
-            "organizationName": organization,
-            "projectCursor": project_cursor,
-            "itemCursor": item_cursor
-        }
+        {"organizationName": organization}
     )
 
     organization_id = result["data"]["organization"]["id"]

--- a/due_date_warner/query_due.py
+++ b/due_date_warner/query_due.py
@@ -1,16 +1,16 @@
 
 
 query_due = """
-query due_items($organizationName: String!, $projectCursor: String, $itemCursor: String) {
+query due_items($organizationName: String!) {
     organization(login: $organizationName) {
         id
-        projectsNext(first: 100, after: $projectCursor) {
+        projectsNext(first: 100) {
             edges {
                 node {
                     id
                     title
                     url
-                    items(first: 100, after: $itemCursor) {
+                    items(first: 100) {
                         edges {
                             node {
                                 id

--- a/due_date_warner/query_due.py
+++ b/due_date_warner/query_due.py
@@ -6,14 +6,12 @@ query due_items($organizationName: String!, $projectCursor: String, $itemCursor:
         id
         projectsNext(first: 100, after: $projectCursor) {
             edges {
-                cursor
                 node {
                     id
                     title
                     url
                     items(first: 100, after: $itemCursor) {
                         edges {
-                            cursor
                             node {
                                 id
                                 title
@@ -28,7 +26,6 @@ query due_items($organizationName: String!, $projectCursor: String, $itemCursor:
                                 type
                                 fieldValues(first: 48) {
                                     edges {
-                                        cursor
                                         node {
                                             projectField {name} 
                                             value


### PR DESCRIPTION
This PR refactors the due-date-warner to use a single pagination processing method (in fact: a generator) to process all pagination, thereby reducing code complexity and duplication.

In addition, processing of field-values pairs, items, and projects is now completely generator-based, thus minimizing the maximum memory requirement